### PR TITLE
Load MathJax on PJAX navigations

### DIFF
--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -12,4 +12,9 @@
 
 <!-- Component loader — MUST be second, use defer (not async) -->
 <script id="MathJax-script" defer
-        src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg.js"></script>
+        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+<script>
+document.addEventListener('page:loaded', () =>
+  window.MathJax?.typesetPromise && MathJax.typesetPromise());
+</script>


### PR DESCRIPTION
## Summary
- refresh math after PaperMod page loads
- update MathJax loader to use tex-mml-chtml build

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a3fb8304833390aeb9657e86c29d